### PR TITLE
fix HueSync rejecting requests from api with a backgroundLighting property set 

### DIFF
--- a/src/sync-box-api.js
+++ b/src/sync-box-api.js
@@ -155,13 +155,13 @@ SyncBoxApi.prototype.handlePost = function (body, response) {
         if (body.options.video) {
             newState.video = {
                 intensity: body.options.video.intensity,
-                backgroundLighting: body.options.video.intensity
+                backgroundLighting: body.options.video.backgroundLighting
             };
         }
         if (body.options.game) {
             newState.game = {
                 intensity: body.options.game.intensity,
-                backgroundLighting: body.options.game.intensity
+                backgroundLighting: body.options.game.backgroundLighting
             };
         }
         if (body.options.music) {


### PR DESCRIPTION
HueSync was rejecting api proxy requests that had backgroundLighting set because it was being given the value of the intensity field by accident.