### PR TITLE
Use new TV_SET_TOP_BOX category

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-philips-hue-sync-box",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Homebridge plugin for the Philips Hue Sync Box. ",
   "license": "MIT",
   "keywords": [

--- a/src/sync-box-device.js
+++ b/src/sync-box-device.js
@@ -37,7 +37,7 @@ function SyncBoxDevice(platform, state) {
     if(platform.config.tvAccessory) {
         platform.log('Setting up accessory with kind TVAccessory.');
         tvAccessory = new Accessory(state.device.name, UUIDGen.generate('TVAccessory'));
-        tvAccessory.category = Categories.TELEVISION;
+        tvAccessory.category = Categories.TV_SET_TOP_BOX;
         tvAccessory.context.kind = 'TVAccessory';
         externalAccessories.push(tvAccessory);
         deviceAccessories.push(tvAccessory);
@@ -48,7 +48,7 @@ function SyncBoxDevice(platform, state) {
     if(platform.config.modeTvAccessory) {
         platform.log('Setting up accessory with kind ModeTVAccessory.');
         modeTvAccessory = new Accessory(state.device.name, UUIDGen.generate('ModeTVAccessory'));
-        modeTvAccessory.category = Categories.TELEVISION;
+        modeTvAccessory.category = Categories.TV_SET_TOP_BOX;
         modeTvAccessory.context.kind = 'ModeTVAccessory';
         externalAccessories.push(modeTvAccessory);
         deviceAccessories.push(modeTvAccessory);
@@ -59,7 +59,7 @@ function SyncBoxDevice(platform, state) {
     if(platform.config.intensityTvAccessory) {
         platform.log('Adding new accessory with kind IntensityTVAccessory.');
         intensityTvAccessory = new Accessory(state.device.name, UUIDGen.generate('IntensityTVAccessory'));
-        intensityTvAccessory.category = Categories.TELEVISION;
+        intensityTvAccessory.category = Categories.TV_SET_TOP_BOX;
         intensityTvAccessory.context.kind = 'IntensityTVAccessory';
         externalAccessories.push(intensityTvAccessory);
         deviceAccessories.push(intensityTvAccessory);


### PR DESCRIPTION
Hi! Thanks for putting together this plugin; I find it extremely valuable.

I noticed recently that HAP-NodeJS added [two new categories for iOS 14](https://github.com/homebridge/HAP-NodeJS/commit/061737c394cbffc6fa901d1efdc23726b00bec69) and I believe the new `TV_SET_TOP_BOX` category does a slightly better job representing the Philips Hue Sync Box than the `TELEVISION` category.

This appears in Apple's Home app as a television icon with a small box: 
![IMG_41E7B3BDB189-1](https://user-images.githubusercontent.com/2146675/93722062-eec00480-fb48-11ea-82ed-0ff438da18c5.jpeg)

What do you think?
