### PR TITLE
fix audioreceiver tv type for modeTvAccessory and intensityTvAccessory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-philips-hue-sync-box",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Homebridge plugin for the Philips Hue Sync Box. ",
   "license": "MIT",
   "keywords": [

--- a/src/sync-box-device.js
+++ b/src/sync-box-device.js
@@ -69,7 +69,7 @@ function SyncBoxDevice(platform, state) {
                 modeTvAccessory.category = Categories.TV_STREAMING_STICK;
                 break;
             case 'audioreceiver':
-                tvAccessory.category = Categories.AUDIO_RECEIVER;
+                modeTvAccessory.category = Categories.AUDIO_RECEIVER;
                 break;
             default:
                 modeTvAccessory.category = Categories.TELEVISION;
@@ -93,7 +93,7 @@ function SyncBoxDevice(platform, state) {
                 intensityTvAccessory.category = Categories.TV_STREAMING_STICK;
                 break;
             case 'audioreceiver':
-                tvAccessory.category = Categories.AUDIO_RECEIVER;
+                intensityTvAccessory.category = Categories.AUDIO_RECEIVER;
                 break;
             default:
                 intensityTvAccessory.category = Categories.TELEVISION;


### PR DESCRIPTION
There's no way to set `mode` and `intensity` tv accessories to `audioreceiver` doing so will remove the type but change the `hdmi` tv accessory type to `audioreceiver`.