### PR TITLE
feat: Show HDMI input names as configured in Hue Sync app instead of always HDMI 1-4

### DIFF
--- a/src/sync-box-device.js
+++ b/src/sync-box-device.js
@@ -213,8 +213,11 @@ function SyncBoxDevice(platform, state) {
                 hdmiInputService = tvAccessory.addService(Service.InputSource, 'hdmi' + i, 'HDMI ' + i);
 
                 // Sets the TV name
+                const hdmiState = state.hdmi['input' + i];
+                const hdmiName = hdmiState.name || ('HDMI ' + i);
+
                 hdmiInputService
-                    .setCharacteristic(Characteristic.ConfiguredName, 'HDMI ' + i)
+                    .setCharacteristic(Characteristic.ConfiguredName, hdmiName)
                     .setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED)
                     .setCharacteristic(Characteristic.CurrentVisibilityState, Characteristic.CurrentVisibilityState.SHOWN)
                     .setCharacteristic(Characteristic.TargetVisibilityState, Characteristic.TargetVisibilityState.SHOWN);


### PR DESCRIPTION
This resolves #34.  The current behavior of this plugin is to force the input names as "HDMI 1" through "HDMI 4", regardless of how they're named in the Hue Sync app.  This changes it to use the names the user configures in the app, like "Apple TV".